### PR TITLE
Lazily start the controller when accessing the effects property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update kotlinx.coroutines to `1.4.3`.
 - Remove kotlin as `api` dependency.
 - Remove `ControllerLog.default`.
+- Lazily start controller when accessing `Controller.effects` field (#26)
 
 ## `[0.13.1]` - 2020-09-13
 

--- a/control-core/src/main/kotlin/at/florianschuster/control/implementation.kt
+++ b/control-core/src/main/kotlin/at/florianschuster/control/implementation.kt
@@ -142,6 +142,7 @@ internal class ControllerImplementation<Action, Mutation, State, Effect>(
         get() = if (stubEnabled) {
             stubbedEffectFlow.receiveAsFlow().cancellable()
         } else {
+            if (controllerStart is ControllerStart.Lazy) start()
             effectsChannel.receiveAsFlow().cancellable()
         }
 


### PR DESCRIPTION
Fixes #26.

The implemented test case fails when not applying the given fix, and is green when applying the fixes.

The test was only quickly implemented, please feel free to adjust the test case to match your preferred test code formatting / organization. 